### PR TITLE
design: 랜딩페이지에 footer 컴포넌트 추가

### DIFF
--- a/front/src/components/common/Footer.tsx
+++ b/front/src/components/common/Footer.tsx
@@ -1,30 +1,30 @@
 import { Link } from "react-router-dom";
 
-const Header = () => {
+const Footer = () => {
   return (
     <footer className="border-b border-[#eee] bg-white w-full">
       <div className="max-w-[1280px] mx-auto px-4 py-4 flex justify-between items-center">
-        <div className="max-w-6xl mx-auto px-4 flex flex-col sm:flex-row justify-between items-center text-sm text-gray-500">
-          {/* 좌측: 로고 */}
-          <div className="mb-4 sm:mb-0 font-semibold text-primary-500 text-lg">
+        {/* 좌측: 로고 */}
+        <div className="text-xl font-bold text-primary-500">
             LiveStudy
-          </div>
+        </div>
 
+        <div className="flex flex-col items-center text-sm text-gray-500">
           {/* 우측: 링크 */}
           <div className="flex gap-4">
             <Link to="/about" className="hover:text-primary-500 transition">서비스 소개</Link>
             <Link to="/terms" className="hover:text-primary-500 transition">이용약관</Link>
             <Link to="/privacy" className="hover:text-primary-500 transition">개인정보처리방침</Link>
           </div>
-      </div>
 
-        {/* 하단 카피라이트 */}
-        <div className="text-center text-xs text-gray-400 mt-4">
-          &copy; 2025 LiveStudy. All rights reserved.
+          {/* 하단 카피라이트 */}
+          <div className="w-full text-right text-xs text-gray-400 mt-4">
+            &copy; 2025 LiveStudy. All rights reserved.
+          </div>
         </div>
       </div>
     </footer>
   );
 };
 
-export default Header;
+export default Footer;

--- a/front/src/page/LandingPage.tsx
+++ b/front/src/page/LandingPage.tsx
@@ -1,4 +1,5 @@
 import { FiClock, FiMessageCircle, FiUsers, FiVideo } from "react-icons/fi";
+import Footer from "../components/common/Footer";
 import Header from "../components/common/Header";
 
 function LandingPage() {
@@ -100,6 +101,7 @@ function LandingPage() {
           </button>
         </div>
       </section>
+      <Footer />
     </div>
   )
 }


### PR DESCRIPTION
랜딩페이지에 공통컴포넌트인 Footer 컴포넌트 추가 완료했습니다.

footer 컴포넌트에 컴포넌트명이 잘못 기입이 되어있었더라구요. 그 부분 수정했고,
landing page에 footer컴포넌트 하단에 추가 완료했습니다.